### PR TITLE
Reduce PR noise

### DIFF
--- a/managedIntegrationDeployment.json
+++ b/managedIntegrationDeployment.json
@@ -1,17 +1,17 @@
 {
   "extends": [
     "github>lifeomic/renovate-config",
-    "github>lifeomic/renovate-config:lambda-8.10"
+    "github>lifeomic/renovate-config:lambda-8.10",
+    "schedule:monthly"
   ],
   "packageRules": [
     {
-      "packagePatterns": [".*"],
-      "excludePackagePatterns": ["^@jupiterone"],
-      "extends": ["schedule:weekly"]
+      "depTypeList": ["devDependencies"],
+      "groupName": "devdeps"
     },
     {
-      "packagePatterns": ["^@jupiterone"],
-      "groupName": "jupiterone packages"
+      "depTypeList": ["dependencies"],
+      "groupName": "deps"
     }
   ],
   "reviewers": ["aiwilliams-lo", "isaacwilliams-lifeomic"]


### PR DESCRIPTION
Reading https://renovatebot.com/docs/noise-reduction/, and considering our CM
process:

1. Cannot use automerge because CMBOT will not accept code without non-author approval

2. Cannot depend on live security updates because that feature only works on GitHub

3. Only trying to keep things relatively up-to-date, do not need to deal with changes so frequently

4. Seems good to limit to two groups so there are two PRs, and groups are dev stuff and release stuff, sorta (the build product comes from dev tools)